### PR TITLE
`pluginColors` option to enable/disable plugin coloring of stylint output

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ See [stylelint options](http://stylelint.io/user-guide/node-api/#options), for t
 * `formatter`: Use a custom formatter to print errors to the console. Default: (`require('stylelint/dist/formatters/stringFormatter').default`)
 * `failOnError`: Have Webpack's build process die on error. Default: `false`
 * `quiet`: Don't print stylelint output to the console. Default: `false`
+* `pluginColors`: Have the plugin color stylelint output. Default: `true`
 
 
 ```js

--- a/index.js
+++ b/index.js
@@ -28,7 +28,10 @@ function apply(options, compiler) {
           return f.source; // send error instead
         });
 
-        (options.quiet !== true) && console.log(chalk.yellow(options.formatter(lint.results)));
+        if (options.quiet !== true) {
+          var lintResults = options.formatter(lint.results);
+          console.log(options.pluginColors ? chalk.yellow(lintResults) : lintResults);
+        }
       }
 
       if (options.failOnError && errors.length) {
@@ -66,6 +69,7 @@ module.exports = function(options) {
   !Array.isArray(options.files) && (options.files = [options.files]);
   options.configFile = options.configFile || '.stylelintrc';
   options.formatter = options.formatter || formatter;
+  options.pluginColors = options.pluginColors !== undefined ? options.pluginColors : true;
   options.quiet = options.quiet || false;
 
   return {


### PR DESCRIPTION
Hi, thanks for your plugin :)

I noticed lint outputs were different when using directly stylelint vs the webpack plugin. I'd rather have the plugin don't affect at all how stylelint output things, and let the formatter handle it.

If it were only me I'd totally delete the coloring done by the plugin, but in order to preserve current behavior I added a `pluginColors` option to handle that.

What do you think?
