### PR TITLE
Fixes #65: Add `emitErrors` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ See [stylelint options](http://stylelint.io/user-guide/node-api/#options) for th
 
 * `configFile`: You can change the config file location. Default: (`undefined`), handled by [stylelint's cosmiconfig module](http://stylelint.io/user-guide/configuration/).
 * `context`: String indicating the root of your SCSS files. Default: inherits from webpack config.
+* `emitErrors`: Display Stylelint errors as actual errors, rather than just warnings. Default: `true`
 * `failOnError`: Have Webpack's build process die on error. Default: `false`
 * `files`: Change the glob pattern for finding files. Default: (`['**/*.s?(a|c)ss']`)
 * `formatter`: Use a custom formatter to print errors to the console. Default: (`require('stylelint').formatters.string`)

--- a/lib/run-compilation.js
+++ b/lib/run-compilation.js
@@ -19,6 +19,10 @@ module.exports = function runCompilation (options, compiler, done) {
     .then(function linterSuccess (lint) {
       var results = lint.results;
 
+      if (options.emitErrors === false) {
+        results = downgradeErrors(results);
+      }
+
       warnings = results.filter(function (file) {
         return !file.errored && file.warnings && file.warnings.length;
       });
@@ -46,14 +50,22 @@ module.exports = function runCompilation (options, compiler, done) {
     }
 
     if (errors.length) {
-      if (options.emitErrors === false) {
-        compilation.warnings.push(chalk.yellow(options.formatter(errors)));
-      } else {
-        compilation.errors.push(chalk.red(options.formatter(errors)));
-      }
+      compilation.errors.push(chalk.red(options.formatter(errors)));
       errors = [];
     }
 
     callback();
   });
 };
+
+/**
+ * Mark errors as warnings as well
+ *
+ * @param lintResults - array of stylelint result objects for each linted file
+ * @return The given results, with all files marked as not containing errors
+ */
+function downgradeErrors (lintResults) {
+  return lintResults.map(function (file) {
+    return Object.assign({}, file, { errored: false });
+  });
+}

--- a/lib/run-compilation.js
+++ b/lib/run-compilation.js
@@ -19,15 +19,11 @@ module.exports = function runCompilation (options, compiler, done) {
     .then(function linterSuccess (lint) {
       var results = lint.results;
 
-      if (options.emitErrors === false) {
-        results = downgradeErrors(results);
-      }
-
-      warnings = results.filter(function (file) {
+      warnings = options.emitErrors === false ? results : results.filter(function (file) {
         return !file.errored && file.warnings && file.warnings.length;
       });
 
-      errors = results.filter(function (file) {
+      errors = options.emitErrors === false ? [] : results.filter(function (file) {
         return file.errored;
       });
 
@@ -57,15 +53,3 @@ module.exports = function runCompilation (options, compiler, done) {
     callback();
   });
 };
-
-/**
- * Mark errors as warnings as well
- *
- * @param lintResults - array of stylelint result objects for each linted file
- * @return The given results, with all files marked as not containing errors
- */
-function downgradeErrors (lintResults) {
-  return lintResults.map(function (file) {
-    return Object.assign({}, file, { errored: false });
-  });
-}

--- a/lib/run-compilation.js
+++ b/lib/run-compilation.js
@@ -46,7 +46,11 @@ module.exports = function runCompilation (options, compiler, done) {
     }
 
     if (errors.length) {
-      compilation.errors.push(chalk.red(options.formatter(errors)));
+      if (options.emitErrors === false) {
+        compilation.warnings.push(chalk.yellow(options.formatter(errors)));
+      } else {
+        compilation.errors.push(chalk.red(options.formatter(errors)));
+      }
       errors = [];
     }
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
   "bugs": {
     "url": "https://github.com/JaKXz/stylelint-webpack-plugin/issues"
   },
+  "engines": {
+    "node": ">=4.0.0"
+  },
   "files": [
     "index.js",
     "lib"

--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
   "bugs": {
     "url": "https://github.com/JaKXz/stylelint-webpack-plugin/issues"
   },
-  "engines": {
-    "node": ">=4.0.0"
-  },
   "files": [
     "index.js",
     "lib"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -249,7 +249,7 @@ describe('stylelint-webpack-plugin', function () {
         });
     });
 
-    it('does not emit errors as warnings when not asked to', function () {
+    it('does not emit errors as warnings when `emitErrors` is not provided', function () {
       var config = {
         context: './test/fixtures/single-error',
         entry: './index',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -57,65 +57,6 @@ describe('stylelint-webpack-plugin', function () {
       });
   });
 
-  it('emits errors as warnings when asked to', function () {
-    var config = {
-      context: './test/fixtures/single-error',
-      entry: './index',
-      plugins: [
-        new StyleLintPlugin({
-          configFile: configFilePath,
-          quiet: true,
-          emitErrors: false
-        })
-      ]
-    };
-
-    return pack(assign({}, baseConfig, config))
-      .then(function (stats) {
-        expect(stats.compilation.errors).to.have.length(0);
-        expect(stats.compilation.warnings).to.have.length(1);
-      });
-  });
-
-  it('does not emit errors as warnings when asked not to', function () {
-    var config = {
-      context: './test/fixtures/single-error',
-      entry: './index',
-      plugins: [
-        new StyleLintPlugin({
-          configFile: configFilePath,
-          quiet: true,
-          emitErrors: true
-        })
-      ]
-    };
-
-    return pack(assign({}, baseConfig, config))
-      .then(function (stats) {
-        expect(stats.compilation.errors).to.have.length(1);
-        expect(stats.compilation.warnings).to.have.length(0);
-      });
-  });
-
-  it('does not emit errors as warnings when not asked to', function () {
-    var config = {
-      context: './test/fixtures/single-error',
-      entry: './index',
-      plugins: [
-        new StyleLintPlugin({
-          configFile: configFilePath,
-          quiet: true
-        })
-      ]
-    };
-
-    return pack(assign({}, baseConfig, config))
-      .then(function (stats) {
-        expect(stats.compilation.errors).to.have.length(1);
-        expect(stats.compilation.warnings).to.have.length(0);
-      });
-  });
-
   it('works with multiple source files', function () {
     var config = {
       context: './test/fixtures/multiple-sources',
@@ -264,6 +205,67 @@ describe('stylelint-webpack-plugin', function () {
             expect(stats.compilation.warnings).to.have.length(1);
           });
       });
+    });
+  });
+
+  context('different values for the `emitErrors` flag', function () {
+    it('emits errors as warnings when asked to', function () {
+      var config = {
+        context: './test/fixtures/single-error',
+        entry: './index',
+        plugins: [
+          new StyleLintPlugin({
+            configFile: configFilePath,
+            quiet: true,
+            emitErrors: false
+          })
+        ]
+      };
+
+      return pack(assign({}, baseConfig, config))
+        .then(function (stats) {
+          expect(stats.compilation.errors).to.have.length(0);
+          expect(stats.compilation.warnings).to.have.length(1);
+        });
+    });
+
+    it('does not emit errors as warnings when asked not to', function () {
+      var config = {
+        context: './test/fixtures/single-error',
+        entry: './index',
+        plugins: [
+          new StyleLintPlugin({
+            configFile: configFilePath,
+            quiet: true,
+            emitErrors: true
+          })
+        ]
+      };
+
+      return pack(assign({}, baseConfig, config))
+        .then(function (stats) {
+          expect(stats.compilation.errors).to.have.length(1);
+          expect(stats.compilation.warnings).to.have.length(0);
+        });
+    });
+
+    it('does not emit errors as warnings when not asked to', function () {
+      var config = {
+        context: './test/fixtures/single-error',
+        entry: './index',
+        plugins: [
+          new StyleLintPlugin({
+            configFile: configFilePath,
+            quiet: true
+          })
+        ]
+      };
+
+      return pack(assign({}, baseConfig, config))
+        .then(function (stats) {
+          expect(stats.compilation.errors).to.have.length(1);
+          expect(stats.compilation.warnings).to.have.length(0);
+        });
     });
   });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -270,5 +270,26 @@ describe('stylelint-webpack-plugin', function () {
           expect(stats.compilation.warnings).to.have.length(0);
         });
     });
+    
+    it('still skips on initial run with `emitErrors` disabled', function () {
+      var config = {
+        context: './test/fixtures/single-error',
+        entry: './index',
+        plugins: [
+          new StyleLintPlugin({
+            configFile: configFilePath,
+            quiet: true,
+            lintDirtyModulesOnly: true,
+            emitErrors: false
+          })
+        ]
+      };
+      
+      return pack(assign({}, baseConfig, config))
+        .then(function (stats) {
+          expect(stats.compilation.errors).to.have.length(0);
+          expect(stats.compilation.warnings).to.have.length(0);
+        });
+    });
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -208,7 +208,7 @@ describe('stylelint-webpack-plugin', function () {
     });
   });
 
-  context('different values for the `emitErrors` flag', function () {
+  context('when `emitErrors` is disabled', function () {
     it('emits errors as warnings when asked to', function () {
       var config = {
         context: './test/fixtures/single-error',
@@ -226,24 +226,6 @@ describe('stylelint-webpack-plugin', function () {
         .then(function (stats) {
           expect(stats.compilation.errors).to.have.length(0);
           expect(stats.compilation.warnings).to.have.length(1);
-        });
-    });
-
-    it('still indicates that errors are errors to the user, even when emitting them as warnings', function () {
-      var config = {
-        context: './test/fixtures/single-error',
-        entry: './index',
-        plugins: [
-          new StyleLintPlugin({
-            configFile: configFilePath,
-            quiet: true,
-            emitErrors: false
-          })
-        ]
-      };
-
-      return pack(assign({}, baseConfig, config))
-        .then(function (stats) {
           expect(stats.compilation.warnings[0]).to.contain('✖');
         });
     });
@@ -264,45 +246,6 @@ describe('stylelint-webpack-plugin', function () {
       return pack(assign({}, baseConfig, config))
         .then(function (stats) {
           expect(stats.compilation.warnings[0]).to.contain('⚠');
-        });
-    });
-
-    it('does not emit errors as warnings when asked not to', function () {
-      var config = {
-        context: './test/fixtures/single-error',
-        entry: './index',
-        plugins: [
-          new StyleLintPlugin({
-            configFile: configFilePath,
-            quiet: true,
-            emitErrors: true
-          })
-        ]
-      };
-
-      return pack(assign({}, baseConfig, config))
-        .then(function (stats) {
-          expect(stats.compilation.errors).to.have.length(1);
-          expect(stats.compilation.warnings).to.have.length(0);
-        });
-    });
-
-    it('does not emit errors as warnings when `emitErrors` is not provided', function () {
-      var config = {
-        context: './test/fixtures/single-error',
-        entry: './index',
-        plugins: [
-          new StyleLintPlugin({
-            configFile: configFilePath,
-            quiet: true
-          })
-        ]
-      };
-
-      return pack(assign({}, baseConfig, config))
-        .then(function (stats) {
-          expect(stats.compilation.errors).to.have.length(1);
-          expect(stats.compilation.warnings).to.have.length(0);
         });
     });
   });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -229,6 +229,44 @@ describe('stylelint-webpack-plugin', function () {
         });
     });
 
+    it('still indicates that errors are errors to the user, even when emitting them as warnings', function () {
+      var config = {
+        context: './test/fixtures/single-error',
+        entry: './index',
+        plugins: [
+          new StyleLintPlugin({
+            configFile: configFilePath,
+            quiet: true,
+            emitErrors: false
+          })
+        ]
+      };
+
+      return pack(assign({}, baseConfig, config))
+        .then(function (stats) {
+          expect(stats.compilation.warnings[0]).to.contain('✖');
+        });
+    });
+
+    it('still indicates that warnings are warnings to the user, even when emitting errors as warnings too', function () {
+      var config = {
+        context: './test/fixtures/rule-warning',
+        entry: './index',
+        plugins: [
+          new StyleLintPlugin({
+            configFile: configFilePath,
+            quiet: true,
+            emitErrors: false
+          })
+        ]
+      };
+
+      return pack(assign({}, baseConfig, config))
+        .then(function (stats) {
+          expect(stats.compilation.warnings[0]).to.contain('⚠');
+        });
+    });
+
     it('does not emit errors as warnings when asked not to', function () {
       var config = {
         context: './test/fixtures/single-error',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -270,7 +270,7 @@ describe('stylelint-webpack-plugin', function () {
           expect(stats.compilation.warnings).to.have.length(0);
         });
     });
-    
+
     it('still skips on initial run with `emitErrors` disabled', function () {
       var config = {
         context: './test/fixtures/single-error',
@@ -284,7 +284,7 @@ describe('stylelint-webpack-plugin', function () {
           })
         ]
       };
-      
+
       return pack(assign({}, baseConfig, config))
         .then(function (stats) {
           expect(stats.compilation.errors).to.have.length(0);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -57,6 +57,65 @@ describe('stylelint-webpack-plugin', function () {
       });
   });
 
+  it('emits errors as warnings when asked to', function () {
+    var config = {
+      context: './test/fixtures/single-error',
+      entry: './index',
+      plugins: [
+        new StyleLintPlugin({
+          configFile: configFilePath,
+          quiet: true,
+          emitErrors: false
+        })
+      ]
+    };
+
+    return pack(assign({}, baseConfig, config))
+      .then(function (stats) {
+        expect(stats.compilation.errors).to.have.length(0);
+        expect(stats.compilation.warnings).to.have.length(1);
+      });
+  });
+
+  it('does not emit errors as warnings when asked not to', function () {
+    var config = {
+      context: './test/fixtures/single-error',
+      entry: './index',
+      plugins: [
+        new StyleLintPlugin({
+          configFile: configFilePath,
+          quiet: true,
+          emitErrors: true
+        })
+      ]
+    };
+
+    return pack(assign({}, baseConfig, config))
+      .then(function (stats) {
+        expect(stats.compilation.errors).to.have.length(1);
+        expect(stats.compilation.warnings).to.have.length(0);
+      });
+  });
+
+  it('does not emit errors as warnings when not asked to', function () {
+    var config = {
+      context: './test/fixtures/single-error',
+      entry: './index',
+      plugins: [
+        new StyleLintPlugin({
+          configFile: configFilePath,
+          quiet: true
+        })
+      ]
+    };
+
+    return pack(assign({}, baseConfig, config))
+      .then(function (stats) {
+        expect(stats.compilation.errors).to.have.length(1);
+        expect(stats.compilation.warnings).to.have.length(0);
+      });
+  });
+
   it('works with multiple source files', function () {
     var config = {
       context: './test/fixtures/multiple-sources',

--- a/test/lib/lint-dirty-modules-plugin.test.js
+++ b/test/lib/lint-dirty-modules-plugin.test.js
@@ -32,7 +32,7 @@ describe('lint-dirty-modules-plugin', function () {
     optionsMock = {
       configFile: configFilePath,
       lintDirtyModulesOnly: true,
-      fomatter: formatter,
+      formatter: formatter,
       files: [glob]
     };
   });


### PR DESCRIPTION
This option allows you to log errors as warnings, preventing
Webpack dev server from aborting compilation.