### PR TITLE
fix: stylelint to webpack error output

### DIFF
--- a/lib/run-compilation.js
+++ b/lib/run-compilation.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var chalk = require('chalk');
 var R = require('ramda');
 var linter = require('./linter');
 var errorMessage = require('./constants').errorMessage;
@@ -41,12 +40,12 @@ module.exports = function runCompilation (options, compiler, done) {
 
   compiler.plugin('after-emit', function afterEmit (compilation, callback) {
     if (warnings.length) {
-      compilation.warnings.push(chalk.yellow(options.formatter(warnings)));
+      compilation.warnings.push(new Error(options.formatter(warnings)));
       warnings = [];
     }
 
     if (errors.length) {
-      compilation.errors.push(chalk.red(options.formatter(errors)));
+      compilation.errors.push(new Error(options.formatter(errors)));
       errors = [];
     }
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   },
   "dependencies": {
     "arrify": "^1.0.1",
-    "chalk": "^1.1.3",
     "minimatch": "^3.0.3",
     "object-assign": "^4.1.0",
     "ramda": "^0.24.1",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -33,8 +33,9 @@ describe('stylelint-webpack-plugin', function () {
     return pack(assign({}, baseConfig, { context: path.resolve('./test/fixtures/multiple-sources') }))
       .then(function (stats) {
         expect(stats.compilation.errors).to.have.length(1);
-        expect(stats.compilation.errors[0]).to.contain('test/fixtures/multiple-sources/_second.scss');
-        expect(stats.compilation.errors[0]).to.contain('test/fixtures/multiple-sources/test.scss');
+        expect(stats.compilation.errors[0]).to.be.an.instanceof(Error);
+        expect(stats.compilation.errors[0].message).to.contain('test/fixtures/multiple-sources/_second.scss');
+        expect(stats.compilation.errors[0].message).to.contain('test/fixtures/multiple-sources/test.scss');
       });
   });
 
@@ -206,7 +207,8 @@ describe('stylelint-webpack-plugin', function () {
         .then(function (stats) {
           expect(stats.compilation.errors).to.have.length(0);
           expect(stats.compilation.warnings).to.have.length(1);
-          expect(stats.compilation.warnings[0]).to.contain('✖');
+          expect(stats.compilation.warnings[0]).to.be.an.instanceof(Error);
+          expect(stats.compilation.warnings[0].message).to.contain('✖');
         });
     });
 
@@ -215,7 +217,8 @@ describe('stylelint-webpack-plugin', function () {
         .then(function (stats) {
           expect(stats.compilation.errors).to.have.length(0);
           expect(stats.compilation.warnings).to.have.length(1);
-          expect(stats.compilation.warnings[0]).to.contain('⚠');
+          expect(stats.compilation.warnings[0]).to.be.an.instanceof(Error);
+          expect(stats.compilation.warnings[0].message).to.contain('⚠');
         });
     });
   });


### PR DESCRIPTION
Hi!
This is an attempt to fix https://github.com/JaKXz/stylelint-webpack-plugin/issues/102

- Remove chalk dep (not used anymore, stylelint already does the coloring)
- Add instances of Error to the compilation errors/warnings arrays
- Update tests

Closes https://github.com/JaKXz/stylelint-webpack-plugin/issues/102