### PR TITLE
fix(console): console.warn should never be called

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ See [stylelint options](http://stylelint.io/user-guide/node-api/#options) for th
 * `formatter`: Use a custom formatter to print errors to the console. Default: `require('stylelint').formatters.string`
 * `lintDirtyModulesOnly`: Lint only changed files, skip lint on start. Default: `false`
 * [`syntax`](https://stylelint.io/user-guide/node-api/#syntax): e.g. use `'scss'` to lint .scss files. Default: `undefined`
-* `quiet`: Prints `stylelint` output directly to the console if negated. Default: `true`.
 
 ## Errors
 

--- a/lib/run-compilation.js
+++ b/lib/run-compilation.js
@@ -27,10 +27,6 @@ module.exports = function runCompilation (options, compiler, done) {
         errors = results.filter(fileHasErrors);
       }
 
-      if (options.quiet === false) {
-        console.warn(options.formatter(results));
-      }
-
       if (options.failOnError && errors.length) {
         done(new Error(errorMessage));
       } else {

--- a/test/helpers/base-config.js
+++ b/test/helpers/base-config.js
@@ -12,7 +12,6 @@ var baseConfig = {
   },
   plugins: [
     new StyleLintPlugin({
-      quiet: true,
       configFile: configFilePath
     })
   ]

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -13,6 +13,16 @@ const configFilePath = getPath('./.stylelintrc');
 const errorMessage = require('../lib/constants').errorMessage;
 
 describe('stylelint-webpack-plugin', function () {
+  beforeEach(function () {
+    td.replace(console, 'warn', td.function());
+  });
+
+  afterEach(function () {
+    // See https://github.com/JaKXz/stylelint-webpack-plugin/issues/61
+    td.verify(console.warn(), { times: 0, ignoreExtraArgs: true });
+    td.reset();
+  });
+
   it('works with a simple file', function () {
     return pack(assign({}, baseConfig, { context: path.resolve('./test/fixtures/lint-free') }))
       .then(function (stats) {
@@ -53,7 +63,6 @@ describe('stylelint-webpack-plugin', function () {
       plugins: [
         new StyleLintPlugin({
           configFile: configFilePath,
-          quiet: true,
           failOnError: true
         })
       ]
@@ -71,8 +80,7 @@ describe('stylelint-webpack-plugin', function () {
       context: path.resolve('./test/fixtures/single-error'),
       plugins: [
         new StyleLintPlugin({
-          configFile: getPath('./.badstylelintrc'),
-          quiet: true
+          configFile: getPath('./.badstylelintrc')
         })
       ]
     };
@@ -82,34 +90,6 @@ describe('stylelint-webpack-plugin', function () {
       .catch(function (err) {
         expect(err.message).to.contain('Failed to parse').and.contain('as JSON');
       });
-  });
-
-  context('iff quiet is strictly false', function () {
-    beforeEach(function () {
-      td.replace(console, 'warn', td.function());
-    });
-
-    afterEach(function () {
-      td.reset();
-    });
-
-    it('sends messages to the console', function () {
-      const config = {
-        context: path.resolve('./test/fixtures/syntax-error'),
-        plugins: [
-          new StyleLintPlugin({
-            configFile: configFilePath,
-            quiet: false
-          })
-        ]
-      };
-
-      return pack(assign({}, baseConfig, config))
-        .then(function (stats) {
-          expect(stats.compilation.errors).to.have.length(1);
-          td.verify(console.warn(td.matchers.contains(/.*/i)));
-        });
-    });
   });
 
   context('without StyleLintPlugin configuration', function () {
@@ -141,8 +121,7 @@ describe('stylelint-webpack-plugin', function () {
         context: path.resolve('./test/fixtures/single-error'),
         plugins: [
           new StyleLintPlugin({
-            configFile: configFilePath,
-            quiet: true
+            configFile: configFilePath
           }),
           new webpack.NoErrorsPlugin()
         ]
@@ -159,7 +138,6 @@ describe('stylelint-webpack-plugin', function () {
         plugins: [
           new StyleLintPlugin({
             configFile: configFilePath,
-            quiet: true,
             failOnError: true
           }),
           new webpack.NoErrorsPlugin()
@@ -188,7 +166,6 @@ describe('stylelint-webpack-plugin', function () {
       plugins: [
         new StyleLintPlugin({
           configFile: configFilePath,
-          quiet: true,
           emitErrors: false
         })
       ]
@@ -230,7 +207,6 @@ describe('stylelint-webpack-plugin', function () {
         plugins: [
           new StyleLintPlugin({
             configFile: configFilePath,
-            quiet: true,
             lintDirtyModulesOnly: true
           })
         ]
@@ -249,7 +225,6 @@ describe('stylelint-webpack-plugin', function () {
         plugins: [
           new StyleLintPlugin({
             configFile: configFilePath,
-            quiet: true,
             lintDirtyModulesOnly: true,
             emitErrors: false
           })

--- a/test/lib/lint-dirty-modules-plugin.test.js
+++ b/test/lib/lint-dirty-modules-plugin.test.js
@@ -1,19 +1,19 @@
 'use strict';
 
-var td = require('testdouble');
-var formatter = require('stylelint').formatters.string;
+const td = require('testdouble');
+const formatter = require('stylelint').formatters.string;
 
-var runCompilation = td.replace('../../lib/run-compilation');
+const runCompilation = td.replace('../../lib/run-compilation');
 
-var LintDirtyModulesPlugin = require('../../lib/lint-dirty-modules-plugin');
+const LintDirtyModulesPlugin = require('../../lib/lint-dirty-modules-plugin');
 
-var configFilePath = getPath('./.stylelintrc');
-var glob = require('../../lib/constants').defaultFilesGlob;
+const configFilePath = getPath('./.stylelintrc');
+const glob = require('../../lib/constants').defaultFilesGlob;
 
 describe('lint-dirty-modules-plugin', function () {
-  var LintDirtyModulesPluginCloned;
-  var compilerMock;
-  var optionsMock;
+  let LintDirtyModulesPluginCloned;
+  let compilerMock;
+  let optionsMock;
 
   beforeEach(function () {
     LintDirtyModulesPluginCloned = function () {
@@ -38,15 +38,15 @@ describe('lint-dirty-modules-plugin', function () {
   });
 
   it('lint is called on "emit"', function () {
-    var lintStub = td.function();
-    var doneStub = td.function();
+    const lintStub = td.function();
+    const doneStub = td.function();
     LintDirtyModulesPluginCloned.prototype.lint = lintStub;
-    var compilationMock = {
+    const compilationMock = {
       fileTimestamps: {
         '/updated.scss': 5
       }
     };
-    var plugin = new LintDirtyModulesPluginCloned(compilerMock, optionsMock);
+    const plugin = new LintDirtyModulesPluginCloned(compilerMock, optionsMock);
 
     compilerMock.callback(compilationMock, doneStub);
 
@@ -55,14 +55,14 @@ describe('lint-dirty-modules-plugin', function () {
   });
 
   context('#lint()', function () {
-    var getChangedFilesStub;
-    var doneStub;
-    var compilationMock;
-    var fileTimestamps = {
+    let getChangedFilesStub;
+    let doneStub;
+    let compilationMock;
+    const fileTimestamps = {
       '/test/changed.scss': 5,
       '/test/newly-created.scss': 5
     };
-    var pluginMock;
+    let pluginMock;
     beforeEach(function () {
       getChangedFilesStub = td.function();
       doneStub = td.function();
@@ -113,7 +113,7 @@ describe('lint-dirty-modules-plugin', function () {
   });
 
   context('#getChangedFiles()', function () {
-    var pluginMock;
+    let pluginMock;
     before(function () {
       pluginMock = {
         compiler: compilerMock,
@@ -129,13 +129,13 @@ describe('lint-dirty-modules-plugin', function () {
     });
 
     it('returns changed style files', function () {
-      var fileTimestamps = {
+      const fileTimestamps = {
         '/test/changed.scss': 20,
         '/test/changed.js': 20,
         '/test/newly-created.scss': 15
       };
 
-      var changedFiles = LintDirtyModulesPluginCloned.prototype.getChangedFiles.call(pluginMock, fileTimestamps, glob);
+      const changedFiles = LintDirtyModulesPluginCloned.prototype.getChangedFiles.call(pluginMock, fileTimestamps, glob);
 
       expect(changedFiles).to.eql([
         '/test/changed.scss',

--- a/test/lib/lint-dirty-modules-plugin.test.js
+++ b/test/lib/lint-dirty-modules-plugin.test.js
@@ -86,8 +86,8 @@ describe('lint-dirty-modules-plugin', function () {
 
       td.verify(doneStub());
       expect(pluginMock.isFirstRun).to.eql(false);
-      td.verify(getChangedFilesStub, {times: 0, ignoreExtraArgs: true});
-      td.verify(runCompilation, {times: 0, ignoreExtraArgs: true});
+      td.verify(getChangedFilesStub(), { times: 0, ignoreExtraArgs: true });
+      td.verify(runCompilation(), { times: 0, ignoreExtraArgs: true });
     });
 
     it('runCompilation is not called if files are not changed', function () {
@@ -96,7 +96,7 @@ describe('lint-dirty-modules-plugin', function () {
       LintDirtyModulesPluginCloned.prototype.lint.call(pluginMock, compilationMock, doneStub);
 
       td.verify(doneStub());
-      td.verify(runCompilation, {times: 0, ignoreExtraArgs: true});
+      td.verify(runCompilation(), { times: 0, ignoreExtraArgs: true });
     });
 
     it('runCompilation is called if styles are changed', function () {


### PR DESCRIPTION
Fixes #61.

nb: I could probably improve the commit message to better address the issue, but the main point is that this plugin should never call the `console.warn` function [which was the only way it would log before].